### PR TITLE
Add support for OAS 3.0.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ SwaggerParser.prototype.parse = function (path, api, options, callback) {
         }
       }
       else {
-        var supportedVersions = ['3.0.0', '3.0.1'];
+        var supportedVersions = ['3.0.0', '3.0.1', '3.0.2'];
 
         // Verify that the parsed object is a Openapi API
         if (schema.openapi === undefined || schema.info === undefined || schema.paths === undefined) {


### PR DESCRIPTION
OAS 3.0.2 is a patch release, there's no changes of the behavior of the spec. 😉 
https://github.com/OAI/OpenAPI-Specification/releases/tag/3.0.2