### PR TITLE
Switch to openapi-schema-validator for v3 schema

### DIFF
--- a/lib/validators/schema.js
+++ b/lib/validators/schema.js
@@ -17,7 +17,7 @@ function validateSchema (api) {
   // Choose the appropriate schema (Swagger or OpenAPI)
   var schema = api.swagger
     ? require("swagger-schema-official/schema.json")
-    : require("openapi-schema-validation/schema/openapi-3.0.json");
+    : require("openapi-schema-validator/dist/resources/openapi-3.0.json");
 
   var isValid = ZSchema.validate(api, schema);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-parser",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3001,8 +3001,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5559,16 +5558,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "jsonschema": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
-    },
-    "jsonschema-draft4": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
-      "integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -7235,6 +7224,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.mergewith": {
       "version": "4.6.1",
@@ -9527,15 +9521,44 @@
         "format-util": "^1.0.3"
       }
     },
-    "openapi-schema-validation": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
-      "integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
+    "openapi-schema-validator": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-3.0.2.tgz",
+      "integrity": "sha512-F9DsY+qCkpSZybH4LFJujuhzBtLcqb0C/7Kcug5m+/wjZ+goPcjiuM82xRQR3G4kzot/NWMiMeJGC1jkIAEw7A==",
       "requires": {
-        "jsonschema": "1.2.4",
-        "jsonschema-draft4": "^1.0.0",
+        "ajv": "^6.5.2",
+        "lodash.merge": "^4.6.1",
+        "openapi-types": "^1.3.1",
         "swagger-schema-official": "2.0.0-bab6bed"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
+          "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
+    },
+    "openapi-types": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.2.tgz",
+      "integrity": "sha512-qhFAj+fhC9+ULRdXKKS4hqtmz3W+I3BlxFgx3xt+60nswk3plYp7FSXQL5JOIYgTbP77dSXsMOWwkrLjixS42w=="
     },
     "optimist": {
       "version": "0.6.1",
@@ -10032,8 +10055,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qjobs": {
       "version": "1.2.0",
@@ -11968,7 +11990,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "call-me-maybe": "^1.0.1",
     "json-schema-ref-parser": "^6.0.2",
     "ono": "^4.0.10",
-    "openapi-schema-validation": "^0.4.2",
+    "openapi-schema-validator": "^3.0.2",
     "swagger-methods": "^1.0.6",
     "swagger-schema-official": "2.0.0-bab6bed",
     "z-schema": "^3.24.1"


### PR DESCRIPTION
According to its npm [README](https://www.npmjs.com/package/openapi-schema-validation) `openapi-schema-validation` is deprecated in favour of the new repository `openapi-schema-validator`

This commit gets rid of the deprecated dependency and replaces it with the new recommended package.