### PR TITLE
moved openapi-types to be a direct dependency to satisfy type definit…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8056,8 +8056,7 @@
     "openapi-types": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-      "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg==",
-      "dev": true
+      "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "node-sass": "^4.12.0",
     "npm-check": "^5.9.0",
     "nyc": "^14.1.1",
-    "openapi-types": "^1.3.5",
     "simplifyify": "^7.0.2",
     "typescript": "^3.5.1",
     "version-bump-prompt": "^5.0.2"
@@ -76,6 +75,7 @@
     "json-schema-ref-parser": "^7.0.1",
     "ono": "^5.0.1",
     "openapi-schema-validation": "^0.4.2",
+    "openapi-types": "^1.3.5",
     "swagger-methods": "^2.0.0",
     "swagger-schema-official": "2.0.0-bab6bed",
     "z-schema": "^4.1.0"


### PR DESCRIPTION
Moved the openapi-types package to be a direct dependency. This will allow the types to be resolved in the included `index.d.ts` file.

Addresses #117 