### PR TITLE
Support openapi version 3.0.3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,7 @@ SwaggerParser.prototype.parse = async function (path, api, options, callback) {
       }
     }
     else {
-      let supportedVersions = ["3.0.0", "3.0.1", "3.0.2"];
+      let supportedVersions = ["3.0.0", "3.0.1", "3.0.2", "3.0.3"];
 
       // Verify that the parsed object is a Openapi API
       if (schema.openapi === undefined || schema.info === undefined || schema.paths === undefined) {


### PR DESCRIPTION
Add support for version 3.0.3

Version was released about 3 weeks ago: https://github.com/OAI/OpenAPI-Specification/releases/tag/3.0.3

