### PR TITLE
fix: Bump z-schema 4.2.3 → 5.0.1 for ReDoS fix in validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2847,6 +2847,16 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -6119,6 +6129,13 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
       "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -13713,9 +13730,9 @@
       }
     },
     "validator": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "verror": {
       "version": "1.10.0",
@@ -13822,6 +13839,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -13957,6 +13975,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -14589,14 +14608,14 @@
       "dev": true
     },
     "z-schema": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
-      "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.1.tgz",
+      "integrity": "sha512-Gp8xU2lULhREqTWj9t4BEAeA7M835n4fWJ9KjGWksV3wmLUdOJo2hAr+QYvkVZIGOOTyeN274g1f95dKRsgYgQ==",
       "requires": {
         "commander": "^2.7.1",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
-        "validator": "^12.0.0"
+        "validator": "^13.6.0"
       }
     },
     "zip-stream": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@apidevtools/swagger-methods": "^3.0.2",
     "@jsdevtools/ono": "^7.1.3",
     "call-me-maybe": "^1.0.1",
-    "z-schema": "^4.2.3"
+    "z-schema": "^5.0.1"
   },
   "peerDependencies": {
     "openapi-types": ">=7"


### PR DESCRIPTION
WIP because the earliest version of `z-schema` that would have the required bump to `validator` is 5.0.1. See https://github.com/zaggino/z-schema/pull/265

Creating this early just to see if any tests fail with the 5.x line of `z-schema`. Note, however, that on `master` there is one failing test (see [CI CD #28](https://github.com/APIDevTools/swagger-parser/runs/2480281288?check_suite_focus=true))

```
  68 passing (12s)
  1 failing

  1) Real-world APIs
       26) akeneo.comakeneo.comakeneo.com:
     MissingPointerError: Token "parent" does not exist.
```

I get the same single failure in this branch