### PR TITLE
Skip known errors or unsupported api in real-world api spec

### DIFF
--- a/test/specs/real-world/fetch-api-list.js
+++ b/test/specs/real-world/fetch-api-list.js
@@ -39,7 +39,7 @@ function deleteProblematicAPIs (apis) {
   delete apis["microsoft.com:graph"];
 
   // hangs
-  delete apis["presalytics.io:ooxml"]
+  delete apis["presalytics.io:ooxml"];
 
   // openapi 3.1.0 not yet supported
   delete apis["adyen.com:AccountService"];

--- a/test/specs/real-world/fetch-api-list.js
+++ b/test/specs/real-world/fetch-api-list.js
@@ -41,6 +41,15 @@ function deleteProblematicAPIs (apis) {
   // hangs
   delete apis["presalytics.io:ooxml"]
 
+  // openapi 3.1.0 not yet supported
+  delete apis["adyen.com:AccountService"];
+  delete apis["adyen.com:BalancePlatformService"];
+  delete apis["adyen.com:CheckoutService"];
+  delete apis["adyen.com:FundService"];
+  delete apis["adyen.com:HopService"];
+  delete apis["adyen.com:MarketPayNotificationService"];
+  delete apis["adyen.com:NotificationConfigurationService"];
+
 }
 
 /**

--- a/test/specs/real-world/fetch-api-list.js
+++ b/test/specs/real-world/fetch-api-list.js
@@ -44,6 +44,7 @@ function deleteProblematicAPIs (apis) {
   // openapi 3.1.0 not yet supported
   delete apis["adyen.com:AccountService"];
   delete apis["adyen.com:BalancePlatformService"];
+  delete apis["adyen.com:BinLookupService"];
   delete apis["adyen.com:CheckoutService"];
   delete apis["adyen.com:FundService"];
   delete apis["adyen.com:HopService"];

--- a/test/specs/real-world/fetch-api-list.js
+++ b/test/specs/real-world/fetch-api-list.js
@@ -37,6 +37,10 @@ function deleteProblematicAPIs (apis) {
   delete apis["docusign.net"];
   delete apis["kubernetes.io"];
   delete apis["microsoft.com:graph"];
+
+  // hangs
+  delete apis["presalytics.io:ooxml"]
+
 }
 
 /**

--- a/test/specs/real-world/fetch-api-list.js
+++ b/test/specs/real-world/fetch-api-list.js
@@ -51,6 +51,9 @@ function deleteProblematicAPIs (apis) {
   delete apis["adyen.com:MarketPayNotificationService"];
   delete apis["adyen.com:NotificationConfigurationService"];
 
+  // base security declaration in path/get operation (error message below)
+  // "type array but found type null at #/paths//vault/callback/get/security"
+  delete apis["apideck.com:vault"];
 }
 
 /**

--- a/test/specs/real-world/known-errors.js
+++ b/test/specs/real-world/known-errors.js
@@ -43,6 +43,12 @@ function getKnownApiErrors () {
       whatToDo: "ignore",
     },
 
+    // Skip openapi 3.1.0
+    {
+      error: "Unsupported OpenAPI version: 3.1.0",
+      whatToDo: "ignore",
+    },
+
     // Many api has info version using date / datetime stamp e.g. amazonaws.com
     {
       error: "Expected type string but found type object at #/info/version",

--- a/test/specs/real-world/known-errors.js
+++ b/test/specs/real-world/known-errors.js
@@ -43,6 +43,72 @@ function getKnownApiErrors () {
       whatToDo: "ignore",
     },
 
+    // Many api has info version using date / datetime stamp e.g. amazonaws.com
+    {
+      error: "Expected type string but found type object at #/info/version",
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "api.video",
+      error: "Data does not match any schemas from 'oneOf'",
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "beanstream.com",
+      error: "Data does not match any schemas from 'anyOf'",
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "github.com",
+      error: 'Token "expires_at" does not exist',
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "github.com",
+      error: 'Token "0" does not exist',
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "googleapis.com",
+      error: "Additional properties not allowed: source at #/",
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "openapi-generator.tech",
+      error: "Additional properties not allowed: originalRef at #/definitions/GeneratorInput/properties/authorizationValue",
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "opensuse.org",
+      error: "Data does not match any schemas from 'oneOf'",
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "parliament.uk",
+      error: "Object didn't pass validation for format uri-reference:  at #/info/contact/url",
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "personio.de",
+      error: 'Token "comment" does not exist',
+      whatToDo: "ignore",
+    },
+
+    {
+      api: "rebilly.com",
+      error: 'Token "feature" does not exist',
+      whatToDo: "ignore",
+    },
+
     // If the API definition failed to download, then retry
     {
       error: /Error downloading https?:/,


### PR DESCRIPTION
I've skipped 3.1.0 yamls which is going to be supported only after https://github.com/APIDevTools/swagger-parser/pull/171

Then I added what I can see are errors with the api to known errors list.

fwiw the spec is also failing on v10.0.2 presumably because the swagger yaml's has changed since last tag (assuming that the build was green when last tag was made) but I'm just trying to get main green asap so that it can get another tag release... so that I can get the z-schema cve fix....
