### PR TITLE
V3 spec checks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "stopOnEntry": false,
       "args": [
         "--quick-test",
-        "--timeout=600000"
+        "--timeout=600000",
+        "Real"
       ],
       "cwd": "${workspaceRoot}",
       "preLaunchTask": null,
@@ -18,7 +19,8 @@
         "--nolazy"
       ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "NODE_TLS_REJECT_UNAUTHORIZED": "0"
       },
       "console": "internalConsole",
       "sourceMaps": false,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ Features
 - Tested on **[over 1,500 real-world APIs](https://apis.guru/browse-apis/)** from Google, Microsoft, Facebook, Spotify, etc.
 - Supports [circular references](https://apitools.dev/swagger-parser/docs/#circular-refs), nested references, back-references, and cross-references
 - Maintains object reference equality &mdash; `$ref` pointers to the same value always resolve to the same object instance
-
+- Checks for inconsistencies in Swagger v2.0 and OpenAPI v3.0 specs:
+  - path parameter mis-matches
+  - required field mis-matches
+  - arrays without item definition
 
 
 Related Projects

--- a/lib/validators/spec.js
+++ b/lib/validators/spec.js
@@ -9,44 +9,89 @@ const schemaTypes = ["array", "boolean", "integer", "number", "string", "object"
 module.exports = validateSpec;
 
 /**
- * Validates parts of the Swagger 2.0 spec that aren't covered by the Swagger 2.0 JSON Schema.
+ * Validates parts of the Swagger 2.0 spec that aren't covered by the Swagger 2.0 JSON Schema;
+ *   and parts of the OpenAPI v3.0.2 spec that aren't covered by the OpenAPI 3.0 JSON SChema
  *
- * @param {SwaggerObject} api
+ * @param {object} api   - the entire Swagger API object
  */
 function validateSpec (api) {
-  if (api.openapi) {
-    // We don't (yet) support validating against the OpenAPI spec
-    return;
-  }
 
   let paths = Object.keys(api.paths || {});
   let operationIds = [];
+
+  // accumulate errors
+  let message = "Specification check failed.\n";
+  let isValid = true;
+
   for (let pathName of paths) {
     let path = api.paths[pathName];
     let pathId = "/paths" + pathName;
 
-    if (path && pathName.indexOf("/") === 0) {
-      validatePath(api, path, pathId, operationIds);
+    try {
+
+      // ...and off we go ...
+      if (path && pathName.indexOf("/") === 0) {
+        validatePath(api, path, pathId, operationIds);
+      }
+    }
+    catch (err) {
+      message += err.message;
+      isValid = false;
+    }
+
+    // in OpenAPI v3.0 they are in re-usable schemas are in #/components/schemas
+    if (api.openapi) {
+      let schemas = Object.keys(api.components?.schemas || {});
+      for (let schemaName of schemas) {
+        let schema = api.components.schemas[schemaName];
+        let schemaId = "/components/schemas/" + schemaName;
+
+        try {
+          validateRequiredPropertiesExist(schema, schemaId);
+        }
+        catch (err) {
+          message += err.message;
+          isValid = false;
+        }
+      }
+    }
+    else {
+      // ... in Swagger v2.0 they were definitions
+      let definitions = Object.keys(api.definitions || {});
+      for (let definitionName of definitions) {
+        let definition = api.definitions[definitionName];
+        let definitionId = "/definitions/" + definitionName;
+
+        try {
+          validateRequiredPropertiesExist(definition, definitionId);
+        }
+        catch (err) {
+          message += err.message;
+          isValid = false;
+        }
+      }
     }
   }
 
-  let definitions = Object.keys(api.definitions || {});
-  for (let definitionName of definitions) {
-    let definition = api.definitions[definitionName];
-    let definitionId = "/definitions/" + definitionName;
-    validateRequiredPropertiesExist(definition, definitionId);
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
   }
 }
 
 /**
  * Validates the given path.
  *
- * @param {SwaggerObject} api           - The entire Swagger API object
+ * @param {object}        api           - The entire Swagger/OpenAPI API object
  * @param {object}        path          - A Path object, from the Swagger API
  * @param {string}        pathId        - A value that uniquely identifies the path
  * @param {string}        operationIds  - An array of collected operationIds found in other paths
  */
 function validatePath (api, path, pathId, operationIds) {
+  // accumulate errors
+  let message = "";
+  let isValid = true;
+
   for (let operationName of swaggerMethods) {
     let operation = path[operationName];
     let operationId = pathId + "/" + operationName;
@@ -58,25 +103,43 @@ function validatePath (api, path, pathId, operationIds) {
           operationIds.push(declaredOperationId);
         }
         else {
-          throw ono.syntax(`Validation failed. Duplicate operation id '${declaredOperationId}'`);
+          message += `Validation failed. Duplicate operation id '${declaredOperationId}'\n`;
+          isValid = false;
         }
       }
-      validateParameters(api, path, pathId, operation, operationId);
+      try {
+        validateParameters(api, path, pathId, operation, operationId);
+      }
+      catch (err) {
+        message += err.message;
+        isValid = false;
+      }
 
       let responses = Object.keys(operation.responses || {});
       for (let responseName of responses) {
         let response = operation.responses[responseName];
         let responseId = operationId + "/responses/" + responseName;
-        validateResponse(responseName, (response || {}), responseId);
+        try {
+          validateResponse(api, responseName, (response || {}), responseId);
+        }
+        catch (err) {
+          message += err.message;
+          isValid = false;
+        }          
       }
     }
   }
+
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
+  }  
 }
 
 /**
  * Validates the parameters for the given operation.
  *
- * @param {SwaggerObject} api           - The entire Swagger API object
+ * @param {object}        api           - The entire Swagger/OpenAPI API object
  * @param {object}        path          - A Path object, from the Swagger API
  * @param {string}        pathId        - A value that uniquely identifies the path
  * @param {object}        operation     - An Operation object, from the Swagger API
@@ -86,12 +149,17 @@ function validateParameters (api, path, pathId, operation, operationId) {
   let pathParams = path.parameters || [];
   let operationParams = operation.parameters || [];
 
+  // accumulate errors
+  let message = "";
+  let isValid = true;
+  
   // Check for duplicate path parameters
   try {
     checkForDuplicates(pathParams);
   }
   catch (e) {
-    throw ono.syntax(e, `Validation failed. ${pathId} has duplicate parameters`);
+    message += `Validation failed. ${pathId} has duplicate parameters\n` + e.message;
+    isValid = false;
   }
 
   // Check for duplicate operation parameters
@@ -99,7 +167,8 @@ function validateParameters (api, path, pathId, operation, operationId) {
     checkForDuplicates(operationParams);
   }
   catch (e) {
-    throw ono.syntax(e, `Validation failed. ${operationId} has duplicate parameters`);
+    message += `Validation failed. ${operationId} has duplicate parameters\n` + e.message;
+    isValid = false;
   }
 
   // Combine the path and operation parameters,
@@ -114,9 +183,32 @@ function validateParameters (api, path, pathId, operation, operationId) {
     return combinedParams;
   }, operationParams.slice());
 
-  validateBodyParameters(params, operationId);
-  validatePathParameters(params, pathId, operationId);
-  validateParameterTypes(params, api, operation, operationId);
+  try {
+    validateBodyParameters(params, operationId);
+  }
+  catch (err) {
+    message += err.message;
+    isValid = false;
+  }
+  try {
+    validatePathParameters(params, pathId, operationId);
+  }
+  catch (err) {
+    message += err.message;
+    isValid = false;
+  }
+  try {
+    validateParameterTypes(params, api, operation, operationId);
+  }
+  catch (err) {
+    message += err.message;
+    isValid = false;
+  }
+
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
+  }  
 }
 
 /**
@@ -129,18 +221,27 @@ function validateBodyParameters (params, operationId) {
   let bodyParams = params.filter((param) => { return param.in === "body"; });
   let formParams = params.filter((param) => { return param.in === "formData"; });
 
+  // accumulate errors
+  let message = "";
+  let isValid = true;
+
   // There can only be one "body" parameter
   if (bodyParams.length > 1) {
-    throw ono.syntax(
-      `Validation failed. ${operationId} has ${bodyParams.length} body parameters. Only one is allowed.`,
-    );
+    message +=
+      `Validation failed. ${operationId} has ${bodyParams.length} body parameters. Only one is allowed.\n`;
+      isValid = false;
   }
   else if (bodyParams.length > 0 && formParams.length > 0) {
     // "body" params and "formData" params are mutually exclusive
-    throw ono.syntax(
-      `Validation failed. ${operationId} has body parameters and formData parameters. Only one or the other is allowed.`,
-    );
+    message +=
+      `Validation failed. ${operationId} has body parameters and formData parameters. Only one or the other is allowed.\n`;
+      isValid = false;
   }
+
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
+  }   
 }
 
 /**
@@ -154,12 +255,17 @@ function validatePathParameters (params, pathId, operationId) {
   // Find all {placeholders} in the path string
   let placeholders = pathId.match(util.swaggerParamRegExp) || [];
 
+  // accumulate errors
+  let message = "";
+  let isValid = true;
+
   // Check for duplicates
   for (let i = 0; i < placeholders.length; i++) {
     for (let j = i + 1; j < placeholders.length; j++) {
       if (placeholders[i] === placeholders[j]) {
-        throw ono.syntax(
-          `Validation failed. ${operationId} has multiple path placeholders named ${placeholders[i]}`);
+        message +=
+          `Validation failed. ${operationId} has multiple path placeholders named ${placeholders[i]}\n`;
+          isValid = false;
       }
     }
   }
@@ -168,24 +274,30 @@ function validatePathParameters (params, pathId, operationId) {
 
   for (let param of params) {
     if (param.required !== true) {
-      throw ono.syntax(
+      message +=
         "Validation failed. Path parameters cannot be optional. " +
-        `Set required=true for the "${param.name}" parameter at ${operationId}`,
-      );
+        `Set required=true for the "${param.name}" parameter at ${operationId}\n`;
+      isValid = false;
     }
     let match = placeholders.indexOf("{" + param.name + "}");
     if (match === -1) {
-      throw ono.syntax(
+      message += 
         `Validation failed. ${operationId} has a path parameter named "${param.name}", ` +
-        `but there is no corresponding {${param.name}} in the path string`
-      );
+        `but there is no corresponding {${param.name}} in the path string\n`;
+      isValid = false;
     }
     placeholders.splice(match, 1);
   }
 
   if (placeholders.length > 0) {
-    throw ono.syntax(`Validation failed. ${operationId} is missing path parameter(s) for ${placeholders}`);
+    message += `Validation failed. ${operationId} is missing path parameter(s) for ${placeholders}\n`;
+    isValid = false;
   }
+
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
+  }  
 }
 
 /**
@@ -197,28 +309,46 @@ function validatePathParameters (params, pathId, operationId) {
  * @param   {string}    operationId  -  A value that uniquely identifies the operation
  */
 function validateParameterTypes (params, api, operation, operationId) {
+
+  // accumulate errors
+  let message = "";
+  let isValid = true;
+  
   for (let param of params) {
     let parameterId = operationId + "/parameters/" + param.name;
     let schema, validTypes;
 
-    switch (param.in) {
-      case "body":
-        schema = param.schema;
-        validTypes = schemaTypes;
-        break;
-      case "formData":
-        schema = param;
-        validTypes = primitiveTypes.concat("file");
-        break;
-      default:
-        schema = param;
-        validTypes = primitiveTypes;
+    // schema is always inside 'schema' tag in openapi specs...
+    if (api.openapi) {
+      schema = param.schema;
+      validTypes = schemaTypes;
+    }
+    else {
+      //  Swagger 2.0 was different...
+      switch (param.in) {
+        case "body":
+          schema = param.schema;
+          validTypes = schemaTypes;
+          break;
+        case "formData":
+          schema = param;
+          validTypes = primitiveTypes.concat("file");
+          break;
+        default:
+          schema = param;
+          validTypes = primitiveTypes;
+      }
     }
 
-    validateSchema(schema, parameterId, validTypes);
-    validateRequiredPropertiesExist(schema, parameterId);
+    try {
+      validateSchema(schema, parameterId, validTypes);
+      validateRequiredPropertiesExist(schema, parameterId);
+    } catch (err) {
+      message += err.message;
+      isValid = false;
+    }
 
-    if (schema.type === "file") {
+    if (schema?.type === "file") {
       // "file" params must consume at least one of these MIME types
       let formData = /multipart\/(.*\+)?form-data/;
       let urlEncoded = /application\/(.*\+)?x-www-form-urlencoded/;
@@ -230,13 +360,18 @@ function validateParameterTypes (params, api, operation, operationId) {
       });
 
       if (!hasValidMimeType) {
-        throw ono.syntax(
+        message += 
           `Validation failed. ${operationId} has a file parameter, so it must consume multipart/form-data ` +
-          "or application/x-www-form-urlencoded",
-        );
+          "or application/x-www-form-urlencoded\n";
+        isValid = false;
       }
-    }
+    }   
   }
+
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
+  }  
 }
 
 /**
@@ -245,45 +380,88 @@ function validateParameterTypes (params, api, operation, operationId) {
  * @param   {object[]}  params  - An array of Parameter objects
  */
 function checkForDuplicates (params) {
+  let message = "";
+  let isValid = true;
+
   for (let i = 0; i < params.length - 1; i++) {
     let outer = params[i];
     for (let j = i + 1; j < params.length; j++) {
       let inner = params[j];
       if (outer.name === inner.name && outer.in === inner.in) {
-        throw ono.syntax(`Validation failed. Found multiple ${outer.in} parameters named "${outer.name}"`);
+        message += `Validation failed. Found multiple ${outer.in} parameters named "${outer.name}"\n`;
+        isValid = false;
       }
     }
   }
+
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
+  }   
 }
 
 /**
  * Validates the given response object.
  *
+ * @param   {object}    api         - The entire Swagger/OpenAPI API object
  * @param   {string}    code        -  The HTTP response code (or "default")
  * @param   {object}    response    -  A Response object, from the Swagger API
  * @param   {string}    responseId  -  A value that uniquely identifies the response
  */
-function validateResponse (code, response, responseId) {
+function validateResponse (api, code, response, responseId) {
+  let message = "";
+  let isValid = true;
+  
   if (code !== "default" && (code < 100 || code > 599)) {
-    throw ono.syntax(`Validation failed. ${responseId} has an invalid response code (${code})`);
+    message += `Validation failed. ${responseId} has an invalid response code (${code})\n`;
+    isValid = false;
   }
 
   let headers = Object.keys(response.headers || {});
   for (let headerName of headers) {
     let header = response.headers[headerName];
     let headerId = responseId + "/headers/" + headerName;
-    validateSchema(header, headerId, primitiveTypes);
+    let schema, validTypes;
+
+    // schema is always inside 'schema' tag in openapi specs...
+    if (api.openapi) {
+      schema = header.schema;
+      validTypes = schemaTypes;
+    }
+    else {
+      //  Swagger 2.0 was different...
+      schema = header;
+      validTypes = primitiveTypes;
+    }
+    try {
+      validateSchema(schema, headerId, validTypes);
+    }
+    catch (err) {
+      message += err.message;
+      isValid = false;
+    }
   }
 
   if (response.schema) {
     let validTypes = schemaTypes.concat("file");
     if (validTypes.indexOf(response.schema.type) === -1) {
-      throw ono.syntax(
-        `Validation failed. ${responseId} has an invalid response schema type (${response.schema.type})`);
+      message +=
+        `Validation failed. ${responseId} has an invalid response schema type (${response.schema.type})\n`;
+        isValid = false;
     }
     else {
-      validateSchema(response.schema, responseId + "/schema", validTypes);
+      try {
+        validateSchema(response.schema, responseId + "/schema", validTypes);
+      } catch (err) {
+        message += err.message;
+        isValid = false;
+      }
     }
+  }
+
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
   }
 }
 
@@ -295,14 +473,24 @@ function validateResponse (code, response, responseId) {
  * @param {string[]}  validTypes  - An array of the allowed schema types
  */
 function validateSchema (schema, schemaId, validTypes) {
+  let message = "";
+  let isValid = true;
+
   if (validTypes.indexOf(schema.type) === -1) {
-    throw ono.syntax(
-      `Validation failed. ${schemaId} has an invalid type (${schema.type})`);
+    message +=
+      `Validation failed. ${schemaId} has an invalid type (${schema.type})\n`;
+      isValid = false;
   }
 
   if (schema.type === "array" && !schema.items) {
-    throw ono.syntax(`Validation failed. ${schemaId} is an array, so it must include an "items" schema`);
+    message += `Validation failed. ${schemaId} is an array, so it must include an "items" schema\n`;
+    isValid = false;
   }
+
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
+  }  
 }
 
 /**
@@ -312,6 +500,7 @@ function validateSchema (schema, schemaId, validTypes) {
  * @param {string}    schemaId    - A value that uniquely identifies the schema object
  */
 function validateRequiredPropertiesExist (schema, schemaId) {
+  
   /**
    * Recursively collects all properties of the schema and its ancestors. They are added to the props object.
    */
@@ -330,15 +519,23 @@ function validateRequiredPropertiesExist (schema, schemaId) {
     }
   }
 
+  let message = "";
+  let isValid = true;
+
   if (schema.required && Array.isArray(schema.required)) {
     let props = {};
     collectProperties(schema, props);
     for (let requiredProperty of schema.required) {
       if (!props[requiredProperty]) {
-        throw ono.syntax(
-          `Validation failed. Property '${requiredProperty}' listed as required but does not exist in '${schemaId}'`
-        );
+        message += 
+          `Validation failed. Property '${requiredProperty}' listed as required but does not exist in '${schemaId}'\n`;
+        isValid = false;
       }
     }
   }
+  
+  //  If we got some errors, then now is the time to throw the exception...
+  if (!isValid) {
+    throw ono.syntax(message);
+  }   
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build:website": "simplifyify online/src/js/index.js --outfile online/js/bundle.js --bundle --debug --minify",
     "build:sass": "node-sass --source-map true --output-style compressed online/src/scss/style.scss online/css/style.min.css",
     "test": "npm run test:node && npm run test:typescript && npm run test:browser && npm run lint",
+    "test:quick": "mocha --quick-test",
     "test:node": "mocha",
     "test:browser": "karma start --single-run",
     "test:typescript": "tsc --noEmit --strict --lib esnext,dom test/specs/typescript-definition.spec.ts",

--- a/test/specs/real-world/known-errors.js
+++ b/test/specs/real-world/known-errors.js
@@ -68,6 +68,62 @@ function getKnownApiErrors () {
       whatToDo: "ignore",
     },
 
+    // adyen.com v3.1.0 schemas seem to be interesting ...
+    {
+      api: "adyen.com",
+      error: "must NOT have unevaluated properties",
+      whatToDo: "ignore"
+    },
+
+    // old field that used to exist included in 'required' ??
+    {
+      api: "airbyte.local:config",
+      error: "Property 'connection' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
+    // old field that used to exist included in 'required' ??
+    {
+      api: "airbyte.local:config",
+      error: "Property 'json_schema' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
+    // old field that used to exist included in 'required' ??
+    {
+      api: "apicurio.local:registry",
+      error: "Property 'group' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
+    // TODO something to investigate
+    {
+      api: "apideck.com:file-storage",
+      error: "Cannot read property 'type' of undefined",
+      whatToDo: "ignore"
+    },
+
+    // old field that used to exist included in 'required' ??
+    {
+      api: "apideck.com:webhook",
+      error: "Property 'data' listed as required but does not exist",
+      whatToDo: "ignore"
+    }, 
+
+    // old field that used to exist included in 'required' ??
+    {
+      api: "apideck.com:hris",
+      error: "Property 'name' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
+    // old field that used to exist included in 'required' ??
+    {
+      api: "atlassian.com:jira",
+      error: "Property 'defaultScreen' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
     // Many Azure API definitions erroneously reference external files that don't exist.
     {
       api: "azure.com",
@@ -96,6 +152,41 @@ function getKnownApiErrors () {
       whatToDo: "ignore",
     },
 
+    // old field that used to exist included in 'required' ??
+    {
+      api: "box.com",
+      error: " Property 'grant_type' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
+    // old field that used to exist included in 'required' ??
+    {
+      api: "britbox.co.uk",
+      error: "Property 'email' listed as required but does not exist ",
+      whatToDo: "ignore"
+    },
+  
+    // old field that used to exist included in 'required' ??
+    {
+      api: "byautomata.io",
+      error: "Property 'terms' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
+    // old field that used to exist included in 'required' ??
+    {
+      api: "cdcgov.local:prime-data-hub",
+      error: "Property 'jurisdictionalFilter' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
+    // old field that used to exist included in 'required' ??
+    {
+      api: "clicksend.com",
+      error: "/paths/uploads?convert={convert}/post is missing path parameter(s) for {convert}",
+      whatToDo: "ignore"
+    },
+
     // Cloudmersive.com's API definition contains invalid JSON Schema types
     {
       api: "cloudmersive.com:ocr",
@@ -110,11 +201,37 @@ function getKnownApiErrors () {
       whatToDo: "ignore",
     },
 
+    // old field that used to exist included in 'required' ??
+    {
+      api: "dataflowkit.com",
+      error: "Property 'proxy' listed as required but does not exist ",
+      whatToDo: "ignore"
+    },
+
+    {
+      api: "digitallocker.gov.in:authpartner",
+      error: "Property 'id' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
     {
       api: "enode.io",
       error: "schema/items must NOT have additional properties",
       whatToDo: "ignore"
     },
+
+    {
+      api: "etsi.local:MEC010-2_AppPkgMgmt",
+      error: "Property 'featureName' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
+    {
+      api: "exavault.com",
+      error: "Property 'homeResource' listed as required but does not exist",
+      whatToDo: "ignore"
+    },
+
     {
       api: "frankiefinancial.io",
       error: "Property 'rowid' listed as required but does not exist",

--- a/test/specs/real-world/real-world.spec.js
+++ b/test/specs/real-world/real-world.spec.js
@@ -26,7 +26,7 @@ describe("Real-world APIs", () => {
     //   1) CI is really slow
     //   2) Some API definitions are HUGE and take a while to download
     //   3) If the download fails, we retry 2 times, which takes even more time
-    //   4) Really large API definitions take longer to pase, dereference, and validate
+    //   4) Really large API definitions take longer to parse, dereference, and validate
     this.currentTest.timeout(host.ci ? 300000 : 60000);     // 5 minutes in CI, 1 minute locally
     this.currentTest.slow(5000);
   });
@@ -52,6 +52,7 @@ describe("Real-world APIs", () => {
    * Downloads an API definition and validates it.  Automatically retries if the download fails.
    */
   async function validateApi (api, attemptNumber = 1) {
+//  if(api.name.includes('atlassian.com'))
     try {
       await SwaggerParser.validate(api.swaggerYamlUrl);
     }
@@ -83,6 +84,7 @@ describe("Real-world APIs", () => {
       else {
         // This is not a known error
         console.error("\n\nERROR IN THIS API:", JSON.stringify(api, null, 2));
+        console.error(JSON.stringify(error, null, 2));
         throw error;
       }
     }

--- a/test/specs/validate-spec/invalid-v3/array-body-no-items.yaml
+++ b/test/specs/validate-spec/invalid-v3/array-body-no-items.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users:
+    get:
+      responses:
+        default:
+          description:  hello world
+          schema:
+            type: array

--- a/test/specs/validate-spec/invalid-v3/array-no-items.yaml
+++ b/test/specs/validate-spec/invalid-v3/array-no-items.yaml
@@ -1,0 +1,16 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users:
+    parameters:
+      - name: tags
+        in: query
+        schema:
+          type: array
+    get:
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/array-response-body-no-items.yaml
+++ b/test/specs/validate-spec/invalid-v3/array-response-body-no-items.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users:
+    get:
+      responses:
+        200:
+          description:  hello world
+          schema:
+            type: array

--- a/test/specs/validate-spec/invalid-v3/array-response-header-no-items.yaml
+++ b/test/specs/validate-spec/invalid-v3/array-response-header-no-items.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users:
+    get:
+      responses:
+        "default":
+          description:  hello world
+          headers:
+            Content-Type:
+              schema:
+                type: string
+            Last-Modified:
+              schema:
+                type: array

--- a/test/specs/validate-spec/invalid-v3/duplicate-operation-ids.yaml
+++ b/test/specs/validate-spec/invalid-v3/duplicate-operation-ids.yaml
@@ -1,0 +1,17 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users:
+    get:
+      operationId: users
+      responses:
+        default:
+          description:  hello world
+    post:
+      operationId: users          # <---- duplicate
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/duplicate-operation-params.yaml
+++ b/test/specs/validate-spec/invalid-v3/duplicate-operation-params.yaml
@@ -1,0 +1,34 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}:
+    get:
+      parameters:
+        - name: username           # <---- Duplicate param
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: bar
+          in: header
+          schema:
+            type: string
+          required: false
+        - name: username          # <---- Another username but in header is ok
+          in: header
+          schema:
+            type: string
+        - name: username          # <---- Another username but in query is ok
+          in: query
+          schema:
+            type: string
+        - name: username           # <---- Duplicate param
+          in: path
+          type: number
+          required: true
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/duplicate-path-params.yaml
+++ b/test/specs/validate-spec/invalid-v3/duplicate-path-params.yaml
@@ -1,0 +1,35 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}:
+    parameters:
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: foo           # <---- Duplicate param
+        in: header
+        schema:
+          type: string
+        required: false
+      - name: username      # <---- Same param but in header is ok
+        in: header
+        schema:
+          type: string
+      - name: username      # <---- Same param but in query is ok
+        in: query
+        schema:
+          type: string
+      - name: foo           # <---- Duplicate param
+        in: header
+        schema:
+          type: number
+        required: true
+    get:
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/duplicate-path-placeholders.yaml
+++ b/test/specs/validate-spec/invalid-v3/duplicate-path-placeholders.yaml
@@ -1,0 +1,22 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}/profile/{username}/image/{img_id}:   # <---- duplicate {username} placeholders
+    parameters:
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: img_id
+        in: path
+        required: true
+        schema:
+          type: number
+    get:
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/file-invalid-consumes.yaml
+++ b/test/specs/validate-spec/invalid-v3/file-invalid-consumes.yaml
@@ -1,0 +1,27 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+consumes:
+  - multipart/form-data                 # <--- The API allows "file" params
+  - application/x-www-form-urlencoded   # <--- The API allows "file" params
+
+paths:
+  /users/{username}/profile/image:
+    parameters:
+      - name: username
+        in: path
+        type: string
+        required: true
+      - name: image
+        in: formData
+        schema:
+          type: file      # <--- "file" params REQUIRE multipart/form-data or application/x-www-form-urlencoded
+    post:
+      consumes:                         # <--- This operation's "consumes" OVERRIDES the API's "consumes"
+        - application/octet-stream
+        - image/png
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/file-no-consumes.yaml
+++ b/test/specs/validate-spec/invalid-v3/file-no-consumes.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}/profile/image:
+    parameters:
+      - name: username
+        in: path
+        schema:
+            type: string
+        required: true
+      - name: image
+        in: formData
+        schema:
+            type: file      # <--- "file" type requires "consumes" to be specified
+    post:
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/multiple-body-params.yaml
+++ b/test/specs/validate-spec/invalid-v3/multiple-body-params.yaml
@@ -1,0 +1,55 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}:
+    parameters:
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: username
+        in: body          # <---- Body param #1
+        schema:
+          type: string
+    get:
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: bar
+          in: header
+          schema:
+            type: number
+          required: true
+        - name: username  # <---- Not an error. This just overrides the path-level param
+          in: body
+          schema:
+            type: number
+      responses:
+        default:
+          description:  hello world
+    post:
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: bar
+          in: header
+          schema:
+            type: number
+          required: true
+        - name: bar
+          in: body          # <---- Body param #2
+          schema:
+            type: number
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/multiple-operation-body-params.yaml
+++ b/test/specs/validate-spec/invalid-v3/multiple-operation-body-params.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}:
+    patch:
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: username
+          in: body          # <---- Body param #1
+          schema:
+            type: string
+        - name: bar
+          in: header
+          schema:
+            type: number
+          required: true
+        - name: bar
+          in: body          # <---- Body param #2
+          schema:
+            type: number
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/multiple-path-body-params.yaml
+++ b/test/specs/validate-spec/invalid-v3/multiple-path-body-params.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}:
+    parameters:
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: username
+        in: body          # <---- Body param #1
+        schema:
+          type: string
+      - name: bar
+        in: header
+        schema:
+          type: number
+        required: true
+      - name: bar
+        in: body          # <---- Body param #2
+        schema:
+          type: number
+    get:
+      responses:
+        default:
+          description:  hello world

--- a/test/specs/validate-spec/invalid-v3/no-path-params.yaml
+++ b/test/specs/validate-spec/invalid-v3/no-path-params.yaml
@@ -1,0 +1,37 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}/{foo}:        # <---- {username} and {foo} placeholders
+    parameters:                   # <---- no path params
+      - $ref: '#/components/parameters/username'
+      - name: foo
+        in: query
+        schema:
+          type: string
+    get:
+      parameters:
+        - $ref: '#/components/parameters/username'
+        - name: foo              #  <----  no path params
+          in: header
+          schema:
+            type: number
+      responses:
+        default:
+          description:  hello world
+    post:
+      parameters:                 # <---- no path params
+        - $ref: '#/components/parameters/username'
+      responses:
+        default:
+          description:  hello world
+components:
+  parameters:
+    username:
+      name: username
+      in: header
+      required: true
+      schema:
+        type: string

--- a/test/specs/validate-spec/invalid-v3/path-param-no-placeholder.yaml
+++ b/test/specs/validate-spec/invalid-v3/path-param-no-placeholder.yaml
@@ -1,0 +1,42 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}:        # <---- {username} placeholder
+    parameters:
+      - $ref: '#/components/parameters/username'
+      - name: foo           # <---- foo in cookie is OK
+        in: cookie
+        schema:
+          type: string
+    get:
+      parameters:
+        - $ref: '#/components/parameters/username'
+        - name: foo         # <---- foo in query is OK
+          in: query
+          schema:
+            type: number
+      responses:
+        default:
+          description:  hello world
+    post:
+      parameters:
+        - $ref: '#/components/parameters/username'
+        - name: foo         # <---- There is no {foo} placeholder
+          in: path
+          required: true
+          schema:
+            type: number
+      responses:
+        default:
+          description:  hello world
+components:
+  parameters:
+    username:
+      name: username
+      in: path
+      required: true
+      schema:
+        type: string

--- a/test/specs/validate-spec/invalid-v3/path-placeholder-no-param.yaml
+++ b/test/specs/validate-spec/invalid-v3/path-placeholder-no-param.yaml
@@ -1,0 +1,37 @@
+openapi: "3.0.2"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users/{username}/{foo}:        # <---- {username} and {foo} placeholders
+    parameters:
+      - $ref: '#/components/parameters/username'            # <---- "username" path param
+      - name: foo                                           # <---- "foo" not in path
+        in: query
+        schema:
+          type: string
+    get:
+      parameters:                   # <---- there's no "foo" path param
+        - $ref: '#/components/parameters/username'            # <---- "username" path param
+        - name: foo                                           # <---- "foo" not in path
+          in: cookie
+          schema:
+            type: number
+      responses:
+        default:
+          description:  hello world
+    post:
+      parameters:                   # <---- there's no "foo" path param
+        - $ref: '#/components/parameters/username'
+      responses:
+        default:
+          description:  hello world
+components:
+  parameters:
+    username:
+      name: username
+      in: path
+      required: true
+      schema:
+        type: string

--- a/test/specs/validate-spec/invalid-v3/required-property-not-defined-definitions.yaml
+++ b/test/specs/validate-spec/invalid-v3/required-property-not-defined-definitions.yaml
@@ -1,0 +1,34 @@
+openapi: "3.0.2"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  '/pet/{petId}':
+      get:
+        summary: Find pet by ID
+        parameters:
+          - name: petId
+            in: path
+            description: ID of pet to return
+            required: true
+            schema:
+              type: integer
+              format: int64
+        responses:
+          '200':
+            description: successful operation
+            schema:
+              $ref: '#/components/responses/Pet'
+components:
+  responses:
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls                        # <--- does not exist
+      properties:
+        name:
+          type: string
+          example: doggie
+        color:
+          type: string

--- a/test/specs/validate-spec/invalid-v3/required-property-not-defined-input.yaml
+++ b/test/specs/validate-spec/invalid-v3/required-property-not-defined-input.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.2
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  /pets:
+    post:
+      description: Creates a new pet in the store
+      parameters:
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            type: object
+            required:
+              - notExists                # <--- does not exist
+            properties:
+              name:
+                type: string
+              color:
+                type: string
+      responses:
+        '200':
+          description: pet response
+          schema:
+            type: object
+            properties:
+              name:
+                type: string

--- a/test/specs/validate-spec/valid-v3/inherited-required-properties.yaml
+++ b/test/specs/validate-spec/valid-v3/inherited-required-properties.yaml
@@ -1,0 +1,58 @@
+openapi: '3.0.2'
+info:
+  contact:
+    x-twitter: hello_iqualify
+  description: >+
+    The iQualify API for testing
+  title: iQualify
+  version: v1
+paths:
+  /offerings:
+    post:
+      description: Creates new offering.
+      requestBody:
+          description: create offering request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OfferingRequired'
+      responses:
+        '201':
+          $ref: '#/components/responses/OfferingMetadataResponse'
+      summary: Create offering
+components:
+  schemas:
+    Offering:
+      properties:
+        contentId:
+          minLength: 1
+          type: string
+        end:
+          format: date-time
+          type: string
+        isReadonly:
+          type: boolean
+        name:
+          minLength: 1
+          type: string
+        start:
+          format: date-time
+          type: string
+    OfferingRequired:
+        allOf:
+          - $ref: '#/components/schemas/Offering'
+        required:
+          - contentId                        # <-- all required properties are inherited
+          - start
+          - end
+  responses:
+    OfferingMetadataResponse:
+      description: Offering response
+      content:
+        text/plain:
+          schema:
+            type: object
+            properties:
+              contentId:
+                minLength: 1
+                type: string


### PR DESCRIPTION
Re-did all my changes from [last June/July](https://github.com/APIDevTools/swagger-parser/pull/179) into the top of main branch.
Hopefully can be picked up this time.

Added checks and validations for v3.0.x OpenAPI schemas to match the pre-existing Swagger (or v2.0) schema checks.
Added more known-errors - now that we're checking v3.0.x schemas, various real-world APIs are naughty.

