### PR TITLE
fix: ignoring a busted API that's breaking unit tests

### DIFF
--- a/test/specs/real-world/known-errors.js
+++ b/test/specs/real-world/known-errors.js
@@ -88,6 +88,12 @@ function getKnownApiErrors () {
       whatToDo: "ignore"
     },
 
+    {
+      api: "adyen.com",
+      error: "must NOT have unevaluated properties",
+      whatToDo: "ignore"
+    },
+
     // They have a description of `2015-04-22T10:03:19.323-07:00` and YAML parsing is converting that to a `Date`.
     // https://github.com/APIDevTools/json-schema-ref-parser/pull/247
     {


### PR DESCRIPTION
Ignoring this API should get all unit tests passing again so we can finally get a release out for 3.1 support.