### PR TITLE
fix: add continueOnError to SwaggerParser.Options

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -272,6 +272,11 @@ declare namespace SwaggerParser {
        */
       spec?: boolean;
     };
+    
+    /**
+     * If set to `true`, don't throw on the first error
+     */
+    continueOnError?: boolean;
   }
 
   export interface HTTPResolverOptions extends Partial<ResolverOptions> {


### PR DESCRIPTION
Adds missing typescript property `continueOnError` to `SwaggerParser.Options`.