### PR TITLE
chore(dependencies): bump @apidevtools/json-schema-ref-parser to 11.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "9.0.6",
+    "@apidevtools/json-schema-ref-parser": "11.6.2",
     "@apidevtools/openapi-schemas": "^2.1.0",
     "@apidevtools/swagger-methods": "^3.0.2",
     "@jsdevtools/ono": "^7.1.3",


### PR DESCRIPTION
A dependency used in this project @apidevtools/json-schema-ref-parser is vulnerable to a prototype pollution attack, as listed in https://nvd.nist.gov/vuln/detail/CVE-2024-29651 - https://github.com/advisories/GHSA-5f97-h2c2-826q

This PR bumps the dependency to prevent any vulnerabilities.

Closes https://github.com/APIDevTools/swagger-parser/issues/255

References
https://ossindex.sonatype.org/vulnerability/CVE-2024-29651
https://github.com/advisories/GHSA-5f97-h2c2-826q
https://github.com/APIDevTools/json-schema-ref-parser/commit/8cad7f72c15b198f4d0b5b1c8a3a979b2e4baa82
https://nvd.nist.gov/vuln/detail/CVE-2024-29651

