### PR TITLE
fix: adds missing version 3.0.4 and 3.1.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,10 @@ const { ono } = require("@jsdevtools/ono");
 const { $RefParser } = require("@apidevtools/json-schema-ref-parser");
 const { dereferenceInternal: dereference } = require("@apidevtools/json-schema-ref-parser");
 
+const supported31Versions = ["3.1.0", "3.1.1"];
+const supported30Versions = ["3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4"];
+const supportedVersions = [...supported31Versions, ...supported30Versions];
+
 /**
  * This class parses a Swagger 2.0 or 3.0 API, resolves its JSON references and their resolved values,
  * and provides methods for traversing, dereferencing, and validating the API.
@@ -56,14 +60,12 @@ class SwaggerParser extends $RefParser {
         }
       }
       else {
-        let supportedVersions = ["3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.1.0"];
-
         // Verify that the parsed object is a Openapi API
         if (schema.openapi === undefined || schema.info === undefined) {
           throw ono.syntax(`${args.path || args.schema} is not a valid Openapi API definition`);
         }
         else if (schema.paths === undefined) {
-          if (schema.openapi === "3.1.0") {
+          if (supported31Versions.indexOf(schema.openapi) !== -1) {
             if (schema.webhooks === undefined) {
               throw ono.syntax(`${args.path || args.schema} is not a valid Openapi API definition`);
             }


### PR DESCRIPTION
fixes https://github.com/microsoft/kiota/issues/5944
# Motivation

OAS 3.1.1 and 3.0.4 were [released as maintenance releases](https://www.openapis.org/blog/2024/10/25/announcing-openapi-specification-patch-releases) and don't change anything from a functional perspective.

We're starting to see those new versions show up in OAS documents, and this library is failing to parse them simply based on the version number.

# Changes

- adds 3.0.4 to the list of supported versions.
- adds 3.1.1 to the list of supported versions.
- moves the version arrays to constants to avoid allocating an array on each call.