### PR TITLE
Fix Import Error: ajv-draft-04

### DIFF
--- a/lib/validators/schema.js
+++ b/lib/validators/schema.js
@@ -2,7 +2,6 @@
 
 const util = require("../util");
 const { ono } = require("@jsdevtools/ono");
-const AjvDraft4 = require("ajv-draft-04");
 const Ajv = require("ajv/dist/2020");
 const { openapi } = require("@apidevtools/openapi-schemas");
 
@@ -70,6 +69,7 @@ function initializeAjv (draft04 = true) {
   };
 
   if (draft04) {
+    const AjvDraft4 = require("ajv-draft-04");
     return new AjvDraft4(opts);
   }
 


### PR DESCRIPTION
Users of this package keep running into the following import issue: This forces users to include `ajv-draft-04` into their project dependencies even if they are not directly using it. This PR proposes moving the import statement into the only code block where it is actually required and thus (hopefully) avoiding the error. Its a bit surprising that the dependencies don't force the package to be there. Maybe there is some other problem at play...

```
node:internal/modules/cjs/loader:1248
  const err = new Error(message);
              ^

Error: Cannot find module 'ajv/dist/core'
Require stack:
- home/project/node_modules/ajv-draft-04/dist/index.js
- home/project/node_modules/@apidevtools/swagger-parser/lib/validators/schema.js
- home/project/node_modules/@apidevtools/swagger-parser/lib/index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1248:15)
    at Module._load (node:internal/modules/cjs/loader:1074:27)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
    at Module.require (node:internal/modules/cjs/loader:1339:12)
    at require (node:internal/modules/helpers:135:16)
    at Object.<anonymous> (home/project/node_modules/ajv-draft-04/dist/index.js:4:16)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1691:10)
    at Module.load (node:internal/modules/cjs/loader:1317:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'home/project/node_modules/ajv-draft-04/dist/index.js',
    'home/project/node_modules/@apidevtools/swagger-parser/lib/validators/schema.js',
    'home/project/node_modules/@apidevtools/swagger-parser/lib/index.js'
  ]
}
```